### PR TITLE
Update to Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["21"]
+        version: ["25"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The important thing here is that we are making the instance by calling a constru
 The code relating to making a record, `ThingRecord`, is just the same, except for different class names. (Once made, things are slightly different too, but that's just as expected.)
 
 ## ThingClass - How this works
-The `bar` and `quux` calls generate wrapped objects (instances of `ThingClass.Args`, which is a sum type of the possible argument types), and they can be passed to a variadic constructor on `ThingClass`. That then extracts the values (simple loop + pattern-matching switch) and sets the real fields appropriately.
+The `bar` and `quux` calls generate wrapped objects (instances of `ThingClass.Args`, which is a sum type of the possible argument types), and they can be passed to a variadic constructor on `ThingClass`. That then extracts the values (simple loop + pattern-matching switch) and sets the real fields appropriately. In Java 25, with [JEP 513](https://openjdk.org/jeps/513) in place, the code for working with a record (`ThingRecord`) is virtually the same as in `ThingClass`, except that the fields are assigned by calling the standard generated constructor.
 
 ```java
 // Defaults
@@ -66,22 +66,6 @@ this.foo = foo;
 this.bar = bar;
 this.grill = grill;
 this.quux = quux;
+// For a record, this last step is instead:
+// this(foo, bar, grill, quux);
 ```
-
-It's a bit messier than that for `ThingRecord` because I'm using an outer record type which requires that all fields are assigned by a call to the canonical constructor as the first statement. This requires (prior to [JEP 513](https://openjdk.org/jeps/513), i.e., Java 25) the use of a static method to do the extraction, and needs the default values to be wrapped instances.
-
-```java
-private static <T extends Args> T select(Args[] args, T defaultValue) {
-    T val = defaultValue;
-    for (var arg: args) {
-        if (arg.getClass() == val.getClass()) {
-            @SuppressWarnings("unchecked")
-            var thisVal = (T) arg;
-            val = thisVal;
-        }
-    }
-    return val;
-}
-```
-
-The unchecked cast is actually safe here (under a trivial non-null assumption), but the language type logic doesn't do that sort of runtime type constraint so we need an unchecked cast anyway.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>not-a-builder</name>
     <description>An experiment in not using the Builder pattern.</description>
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <url>https://dkfellows.github.io/not-a-builder</url>

--- a/src/main/java/com/github/dkfellows/notabuilder/ThingRecord.java
+++ b/src/main/java/com/github/dkfellows/notabuilder/ThingRecord.java
@@ -8,32 +8,8 @@ package com.github.dkfellows.notabuilder;
  * @param quux The quux field.
  */
 public record ThingRecord(int foo, int bar, double grill, String quux) {
-    private static final Foo DEFAULT_FOO = new Foo(0);
-    private static final Bar DEFAULT_BAR = new Bar(0);
-    private static final Grill DEFAULT_GRILL = new Grill(0.0);
-    private static final Quux DEFAULT_QUUX = new Quux("");
-
-    /** Helper because the canonical constructor must be called as the first statement.
-     * @param <T> The type of argument being extracted.
-     * @param args The argument list to extract from.
-     * @param defaultValue The default for the argument being extracted.
-     *      Note that <em>this also tells the runtime code what argument to extract</em>.
-     * @return The extracted argument, if present, or a default.
-     */
-    private static <T extends Args> T select(Args[] args, T defaultValue) {
-        T val = defaultValue;
-        for (var arg: args) {
-            if (arg.getClass() == val.getClass()) {
-                @SuppressWarnings("unchecked")
-                var thisVal = (T) arg;
-                val = thisVal;
-            }
-        }
-        return val;
-    }
-
     /**
-     * Make an instance of the record. 
+     * Make an instance of the record.
      * @param args The labelled non-default arguments to pass.
      * @see ThingRecord.Args#foo(int)
      * @see ThingRecord.Args#bar(int)
@@ -41,10 +17,24 @@ public record ThingRecord(int foo, int bar, double grill, String quux) {
      * @see ThingRecord.Args#quux(String)
      */
     public ThingRecord(Args... args) {
-        this(select(args, DEFAULT_FOO).foo(),
-            select(args, DEFAULT_BAR).bar(),
-            select(args, DEFAULT_GRILL).grill(),
-            select(args, DEFAULT_QUUX).quux());
+        // Defaults
+        var foo = 0;
+        var bar = 0;
+        var grill = 0.0;
+        var quux = "";
+
+        // Extract the args
+        for (var arg: args) {
+            switch (arg) {
+            case Foo f -> foo = f.foo();
+            case Bar b -> bar = b.bar();
+            case Grill g -> grill = g.grill();
+            case Quux q -> quux = q.quux();
+            }
+        }
+
+        // Pass to the primary, auto-generated constructor
+        this(foo, bar, grill, quux);
     }
 
     /** Argument labeller. */
@@ -57,7 +47,7 @@ public record ThingRecord(int foo, int bar, double grill, String quux) {
         public static Args foo(int value) {
             return new Foo(value);
         }
-    
+
         /**
          * Label a value as a {@link ThingRecord#bar()}.
          * @param value The value to label.
@@ -66,7 +56,7 @@ public record ThingRecord(int foo, int bar, double grill, String quux) {
         public static Args bar(int value) {
             return new Bar(value);
         }
-    
+
         /**
          * Label a value as a {@link ThingRecord#grill()}.
          * @param value The value to label.
@@ -75,7 +65,7 @@ public record ThingRecord(int foo, int bar, double grill, String quux) {
         public static Args grill(double value) {
             return new Grill(value);
         }
-    
+
         /**
          * Label a value as a {@link ThingRecord#quux()}.
          * @param value The value to label.
@@ -85,9 +75,9 @@ public record ThingRecord(int foo, int bar, double grill, String quux) {
             return new Quux(value);
         }
     }
-    
+
     private record Foo(int foo) implements Args {}
     private record Bar(int bar) implements Args {}
     private record Grill(double grill) implements Args {}
     private record Quux(String quux) implements Args {}
-}    
+}


### PR DESCRIPTION
This updates the code to work with Java 25.

The only relevant change is that [JEP 513](https://openjdk.org/jeps/513) allows me to make the internals of `ThingRecord` much simpler, and much more like `ThingClass` (i.e., no static helper method). Which is neat.